### PR TITLE
Add FrameSet record type with relationship-based design

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ContextFrame addresses these challenges by leveraging the `.lance` format's stre
 -   **Lance-Based**: Built on the high-performance, version-aware `.lance` format.
 -   **Rich, Editable & Standardized Metadata**: Comprehensive schema for essential document details, including provenance, collections, status, **and importantly, user-editable fields (`context`, `custom_metadata`) for adding workflow-specific relevance and annotations.**
 -   **Optional Raw Multimodal Data**  Store raw binary data (images, audio, video, PDFs, etc.) directly in the dataset using the **`raw_data`** (bytes) and **`raw_data_type`** (IANA MIME type) columns added to the canonical schema.  A helper `MimeTypes` enum under `contextframe.schema` exposes common constants (e.g., `MimeTypes.IMAGE_JPEG`).
--   **Explicit Record Typing**  The `RecordType` enum (`contextframe.schema.RecordType`) provides canonical constants (`DOCUMENT`, `COLLECTION_HEADER`, `DATASET_HEADER`).
+-   **Explicit Record Typing**  The `RecordType` enum (`contextframe.schema.RecordType`) provides canonical constants (`DOCUMENT`, `COLLECTION_HEADER`, `DATASET_HEADER`, `FRAMESET`).
 -   **Explicit Relationships**: Dedicated schema support and helpers for defining connections between documents.
 -   **Vector Embedding Support**: Natively handles vector embeddings alongside text and metadata.
 -   **Schema Validation**: Ensures data consistency and integrity against the ContextFrame specification.

--- a/contextframe/frame.py
+++ b/contextframe/frame.py
@@ -1337,7 +1337,7 @@ class FrameDataset:
         """Get all frames referenced by a frameset.
 
         This method retrieves the actual frame records that are included in
-        the frameset, based on the frame_uuids stored in the frameset's metadata.
+        the frameset, based on the relationships stored in the frameset's metadata.
 
         Parameters
         ----------
@@ -1359,19 +1359,52 @@ class FrameDataset:
         if not frameset:
             raise ValueError(f"FrameSet {frameset_uuid} not found")
 
-        # Extract frame UUIDs from metadata
-        frame_uuids = frameset.metadata.get("frame_uuids", [])
-        if not frame_uuids:
-            return []
-
-        # Retrieve all frames by their UUIDs
+        # Extract frame UUIDs from relationships
+        # Framesets use the "contains" relationship type to reference their member frames
+        # This allows us to track which documents are part of the frameset while
+        # keeping frameset-specific metadata (like source_query) in custom_metadata
         frames = []
-        for uuid in frame_uuids:
-            frame = self.get_by_uuid(uuid)
-            if frame:
-                frames.append(frame)
+        for rel in frameset.metadata.get("relationships", []):
+            if rel.get("type") == "contains" and rel.get("id"):
+                frame = self.get_by_uuid(rel["id"])
+                if frame:
+                    frames.append(frame)
 
         return frames
+
+    def get_frameset_frame_count(self, frameset_uuid: str) -> int:
+        """Get the number of frames in a frameset.
+
+        This method counts the number of "contains" relationships in the frameset,
+        which is more reliable than storing a static count that could become
+        out of sync.
+
+        Parameters
+        ----------
+        frameset_uuid:
+            UUID of the frameset
+
+        Returns
+        -------
+        int
+            Number of frames contained in the frameset
+
+        Raises
+        ------
+        ValueError
+            If the frameset is not found
+        """
+        frameset = self.get_frameset(frameset_uuid)
+        if not frameset:
+            raise ValueError(f"FrameSet {frameset_uuid} not found")
+
+        # Count relationships with type="contains"
+        count = 0
+        for rel in frameset.metadata.get("relationships", []):
+            if rel.get("type") == "contains":
+                count += 1
+
+        return count
 
     def find_by_status(self, status: str) -> list[FrameRecord]:
         """Return all records whose ``status`` metadata exactly matches *status*.

--- a/contextframe/frame.py
+++ b/contextframe/frame.py
@@ -1246,6 +1246,59 @@ class FrameDataset:
         """
         return self.find_by_record_type("frameset")
 
+    def get_frameset_headers(self) -> list[FrameRecord]:
+        """Get all frameset header records in the dataset.
+
+        This is an alias for list_framesets() to match the naming convention
+        in the Linear issue.
+
+        Returns
+        -------
+        List[FrameRecord]
+            All records with record_type='frameset'
+        """
+        return self.list_framesets()
+
+    def get_frameset_frames(self, frameset_uuid: str) -> list[FrameRecord]:
+        """Get all frames referenced by a frameset.
+
+        This method retrieves the actual frame records that are included in
+        the frameset, based on the frame_uuids stored in the frameset's metadata.
+
+        Parameters
+        ----------
+        frameset_uuid:
+            UUID of the frameset
+
+        Returns
+        -------
+        List[FrameRecord]
+            List of frame records included in the frameset
+
+        Raises
+        ------
+        ValueError
+            If the frameset is not found or is not a valid frameset
+        """
+        # Get the frameset record
+        frameset = self.get_frameset(frameset_uuid)
+        if not frameset:
+            raise ValueError(f"FrameSet {frameset_uuid} not found")
+
+        # Extract frame UUIDs from metadata
+        frame_uuids = frameset.metadata.get("frame_uuids", [])
+        if not frame_uuids:
+            return []
+
+        # Retrieve all frames by their UUIDs
+        frames = []
+        for uuid in frame_uuids:
+            frame = self.get_by_uuid(uuid)
+            if frame:
+                frames.append(frame)
+
+        return frames
+
     def find_by_status(self, status: str) -> list[FrameRecord]:
         """Return all records whose ``status`` metadata exactly matches *status*.
 

--- a/contextframe/helpers/metadata_utils.py
+++ b/contextframe/helpers/metadata_utils.py
@@ -51,7 +51,7 @@ STANDARD_METADATA_FIELDS: dict[str, dict[str, Any]] = {
     },
 }
 
-VALID_RELATIONSHIP_TYPES = {"parent", "child", "related", "reference", "member_of"}
+VALID_RELATIONSHIP_TYPES = {"parent", "child", "related", "reference", "member_of", "contains"}
 
 # ---------------------------------------------------------------------------
 # Simple primitives

--- a/contextframe/schema/contextframe_schema.json
+++ b/contextframe/schema/contextframe_schema.json
@@ -301,6 +301,28 @@
           }
         }
       }
+    },
+    "frame_count": {
+      "type": "integer",
+      "description": "Number of frames in this FrameSet (only for frameset record_type)",
+      "minimum": 0
+    },
+    "frame_uuids": {
+      "type": "array",
+      "description": "List of frame UUIDs included in this FrameSet (only for frameset record_type)",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+      }
+    },
+    "source_query": {
+      "type": "string",
+      "description": "The query that generated this FrameSet (only for frameset record_type)"
+    },
+    "export_format": {
+      "type": "string",
+      "description": "Preferred export format for this FrameSet (only for frameset record_type)",
+      "enum": ["markdown", "json", "yaml", "claude", "gpt", "langchain"]
     }
   },
   "patternProperties": {

--- a/contextframe/schema/contextframe_schema.json
+++ b/contextframe/schema/contextframe_schema.json
@@ -153,7 +153,8 @@
               "parent",
               "child",
               "related",
-              "reference"
+              "reference",
+              "contains"
             ]
           },
           "id": {
@@ -308,28 +309,6 @@
       "additionalProperties": {
         "type": "string"
       }
-    },
-    "frame_count": {
-      "type": "integer",
-      "description": "Number of frames in this FrameSet (only for frameset record_type)",
-      "minimum": 0
-    },
-    "frame_uuids": {
-      "type": "array",
-      "description": "List of frame UUIDs included in this FrameSet (only for frameset record_type)",
-      "items": {
-        "type": "string",
-        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-      }
-    },
-    "source_query": {
-      "type": "string",
-      "description": "The query that generated this FrameSet (only for frameset record_type)"
-    },
-    "export_format": {
-      "type": "string",
-      "description": "Preferred export format for this FrameSet (only for frameset record_type)",
-      "enum": ["markdown", "json", "yaml", "claude", "gpt", "langchain"]
     }
   },
   "patternProperties": {


### PR DESCRIPTION
## Summary
- Implements CFOS-20: Add FrameSet Record Type
- Makes FrameSets first-class citizens in ContextFrame for storing search results and curated collections
- Uses elegant relationship-based design that leverages existing schema patterns

## Design Approach
After careful consideration and iteration, we chose an elegant solution that:
- Uses the existing `relationships` field with a new "contains" type for tracking frame references
- Stores only essential frameset metadata (`source_query`) in `custom_metadata`
- Avoids storing derived data like frame counts that can be calculated dynamically
- Removes unnecessary fields (`export_format`, `frame_count`) for a cleaner design

## Changes
- Added "frameset" to `RecordType` enum in both JSON and Arrow schemas
- Added "contains" as a valid relationship type for framesets
- Implemented comprehensive frameset management methods:
  - `create_frameset()` - Create framesets from search results
  - `get_frameset()` - Retrieve frameset by UUID
  - `get_frameset_frames()` - Get all frames in a frameset
  - `get_frameset_frame_count()` - Dynamically count frames
  - `list_framesets()` / `get_frameset_headers()` - List all framesets
  - `update_frameset_content()` - Update frameset content
  - `find_framesets_by_query()` - Find by original query
  - `find_framesets_referencing()` - Find framesets containing a document
- Added comprehensive test coverage for all functionality

## Benefits
- Consistent with existing ContextFrame patterns
- No schema bloat with frameset-specific fields
- Dynamic frame counting prevents data inconsistency
- Clean separation between data storage and presentation concerns
- Fully backward compatible

## Test plan
- [x] All frameset tests pass
- [x] No regression in existing tests
- [x] Schema validation works correctly
- [x] Relationship-based frame tracking functions properly